### PR TITLE
Initial version of natalie-lang.org/specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-specs
+specs/current.json
+specs/stats.json

--- a/specs/directory_node.js
+++ b/specs/directory_node.js
@@ -1,0 +1,60 @@
+class DirectoryNode extends Node {
+  createChildren() {
+    this.children = []
+    Object.entries(this.data).forEach(([key, value]) => {
+      if(value.compiled !== undefined) {
+        this.children.push(new FileNode(key, this, value))
+      } else {
+        this.children.push(new DirectoryNode(key, this, value))
+      }
+    })
+  }
+
+  render(opened = false) {
+    super.render(opened)
+    this.addSpecLinkToHeader(this.path.slice(1).join('/'))
+
+    if(opened) {
+      this.renderChildren()
+    }
+
+    var statsContainer = document.createElement('div')
+    statsContainer.classList.add('tree-view-stats');
+    statsContainer.style.marginRight = '200px';
+    ['compiled', 'crashed', 'timeouted', 'success', 'failures', 'errors'].forEach(type => {
+      var counterContainer = this.createStatsCounter(type, this.getChildrenStatsCount(type))
+      statsContainer.append(counterContainer)
+    })
+    this.header.append(statsContainer);
+  }
+
+  // Adding up the stats of one type for each spec file in this directory.
+  getChildrenStatsCount(type) {
+    var count = 0;
+    this.children.forEach(child => {
+      if(child instanceof FileNode) {
+        // When 'compiled' is specified we actually want the number of compilation errors.
+        if(type !== 'compiled') {
+          count += child.data[type]
+        } else {
+          count += !child.data[type]
+        }
+      } else {
+        count += child.getChildrenStatsCount(type)
+      }
+    })
+    return count
+  }
+
+  // Open this node if needed and also open all children recursively.
+  openRecursively() {
+    if(!this.container.classList.contains('active')) {
+      this.open()
+    }
+
+    this.children.forEach(child => {
+      if(child instanceof FileNode) return
+      child.openRecursively()
+    })
+  }
+}

--- a/specs/error_message_node.js
+++ b/specs/error_message_node.js
@@ -1,0 +1,43 @@
+class ErrorMessageNode extends Node {
+  // An error message node has no children.
+  createChildren() {
+    this.children = []
+  }
+
+  render() {
+    super.render()
+
+    var messageParts = this.data.split('\n')
+    var spec = messageParts[0]
+    var backtrace = messageParts[messageParts.length - 1]
+    var error = messageParts.slice(1, messageParts.length - 1).join('\n');
+
+    this.header.querySelector('.tree-view-title').textContent = `${spec} `
+    var errorMessageContainer = document.createElement('pre')
+    errorMessageContainer.classList.add('error-message')
+    errorMessageContainer.textContent = error.replaceAll('\n', '\\n')
+    errorMessageContainer.textContent += '\n\n'
+    try {
+      backtrace = JSON.parse(backtrace)
+      backtrace = backtrace.map(line => line.replace('/home/runner/work/natalie/', ''))
+
+      for(var line of backtrace) {
+        if(line.startsWith('natalie/spec') || line.startsWith('spec')) {
+          var [path, lineNumber] = line.split(':')
+          if(path && lineNumber) {
+            path = path.split('/')
+            if(path[0] == 'natalie') path.shift()
+
+            this.addSpecLinkToHeader(`${path.slice(1).join('/')}#L${lineNumber}`);
+            break
+          }
+        }
+      }
+
+      errorMessageContainer.textContent += backtrace.join('\n')
+    } catch(e) {
+      console.log(`failed to parse ${backtrace} (spec: ${spec})\n${e}`)
+    }
+    this.container.append(errorMessageContainer)
+  }
+}

--- a/specs/file_node.js
+++ b/specs/file_node.js
@@ -1,0 +1,53 @@
+class FileNode extends Node {
+  createChildren() {
+    this.children = []
+
+    for(var [i, message] of this.data.error_messages.entries()) {
+      this.children.push(new ErrorMessageNode(`error_${i}`, this, message))
+    }
+  }
+
+  render() {
+    super.render()
+
+    this.addSpecLinkToHeader(this.path.slice(1).join('/'))
+    var statsContainer = document.createElement('div')
+    statsContainer.classList.add('tree-view-stats')
+    if(!this.data.compiled) {
+      statsContainer.style.fontWeight = 'bold'
+      statsContainer.textContent = 'Compilation Error'
+    } else
+    if(this.data.timeouted) {
+      statsContainer.style.fontWeight = 'bold'
+      statsContainer.style.color = '#888888'
+      statsContainer.textContent = 'Timed Out'
+    } else
+    if(this.data.crashed) {
+      statsContainer.style.fontWeight = 'bold'
+      statsContainer.style.color = '#830a46'
+      statsContainer.textContent = 'Crashed'
+    } else {
+      ['success', 'failures', 'errors'].forEach(type => {
+        var counter = this.createStatsCounter(type, this.data[type])
+        statsContainer.append(counter);
+      })
+
+      var progressBar = document.createElement('div')
+      var total = this.data.success + this.data.errors + this.data.failures
+      progressBar.classList.add('progress-bar');
+      ['success', 'failures', 'errors'].forEach(type => {
+        var part = document.createElement('div')
+        part.classList.add(`progress-bar-${type}`)
+        part.style.width = (this.data[type] / total * 100) + '%'
+        progressBar.append(part)
+      })
+      statsContainer.append(progressBar)
+    }
+
+    this.header.append(statsContainer);
+    if(this.data.error_messages.length === 0) {
+      this.header.removeAttribute('for')
+      this.container.remove()
+    }
+  }
+}

--- a/specs/index.html
+++ b/specs/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Spec Results | Natalie Programming Language</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/typesafe.css">
+    <link rel="stylesheet" href="/specs/tree-view.css">
+    <style> pre { border: none; }</style>
+    <script src="/specs/node.js"></script>
+    <script src="/specs/file_node.js"></script>
+    <script src="/specs/directory_node.js"></script>
+    <script src="/specs/error_message_node.js"></script>
+    <script src="/specs/tree_view.js"></script>
+    <script src="/specs/specs.js"></script>
+  </head>
+  <body style="min-width: 80%">
+    <h1>Is Natalie Ruby Yet?</h1>
+    <p>Those are the current results of the <a href="https://www.github.com/ruby/spec" target="_blank" rel="noopener noreferrer">ruby/spec</a> suite running with <a href="/">Natalie</a>.<span style="visibility: hidden"> The specs were completed at <span id="spec-date"></span>.</div></p>
+    <label for="search">Search:</label>
+    <input id="search" />
+    <div class="tree-view-root" level="0"></div>
+  </body>
+</html>

--- a/specs/node.js
+++ b/specs/node.js
@@ -1,0 +1,106 @@
+class Node {
+  constructor(name, parent, data) {
+    this.name = name
+    this.parent = parent
+    this.data = data
+    if(parent.path) {
+      this.path = parent.path.concat(name)
+    } else {
+      this.path = [name]
+    }
+    this.renderedChildren = false
+    this.createChildren()
+  }
+
+  render(opened = false) {
+    var root = this.parent.container
+    var level = parseInt(root.getAttribute('level')) + 1
+    var rootId = root.hasAttribute('id') ? `${root.getAttribute('id')}_` : ''
+    var id = `${rootId}${(id ? id : this.name.replaceAll('.', '_'))}`;
+
+    var header = document.createElement('div')
+    header.classList.add('tree-view-header')
+    header.setAttribute('for', id)
+    var title = document.createElement('div')
+    title.classList.add('tree-view-title')
+    title.textContent = `${this.name} `
+
+    header.append(title)
+    root.append(header)
+
+    var body = document.createElement('div')
+    body.classList.add('tree-view-body')
+    if(opened) {
+      header.classList.add('active')
+      body.classList.add('active')
+    }
+    body.setAttribute('id', id)
+    body.dataset.path = this.path.join('/')
+    body.setAttribute('level', level)
+    body.style.marginLeft = `${level * 10}px`
+    root.append(body);
+
+    this.container = body
+    this.header = header
+  }
+
+  // This adds a link to the ruby/spec github repository.
+  // This could be not 100% correct, considering that new commits may have been added to
+  // master already. If we want to make this accurate, we have to transmit the commit sha
+  // of the commit that we ran the specs with.
+  addSpecLinkToHeader(linkPath) {
+    var title = this.header.querySelector('.tree-view-title')
+    var linkContainer = document.createElement('a')
+    linkContainer.href = `https://www.github.com/ruby/spec/tree/master/${linkPath}`
+    linkContainer.target = '_blank'
+    linkContainer.rel = 'noopener noreferrer'
+    linkContainer.textContent = '🡕'
+    title.innerHTML += ' '
+    title.append(linkContainer)
+  }
+
+  // Create an element that portraits a specific spec stat (like successful examples).
+  createStatsCounter(type, count) {
+    var counterContainer = document.createElement('div')
+    counterContainer.classList.add('stats-counter', type)
+    var counter = document.createElement('div')
+    counter.textContent = count
+    counterContainer.prepend(counter)
+    return counterContainer
+  }
+
+  // Call #render for all children.
+  renderChildren(opened = false) {
+    if(this.renderedChildren) {
+      console.warn('Tried to render children while all children were already rendered.')
+      return
+    }
+
+    this.children.forEach(child => {
+      child.render(opened);
+    })
+    this.renderedChildren = true
+  }
+
+  findChildNode(name) {
+    return this.children.find(child => child.name === name)
+  }
+
+  // Openes a node. If the children were not rendered already, they get rendered.
+  open() {
+    if(!this.renderedChildren) {
+      this.renderChildren()
+    }
+    this.header.classList.add('active')
+    this.container.classList.add('active')
+  }
+
+  // This closes this node and all inner nodes.
+  close() {
+    if(this.header)
+      this.header.classList.remove('active')
+    this.container.classList.remove('active')
+    if(this.renderedChildren)
+      this.children.forEach(child => child.close())
+  }
+}

--- a/specs/specs.js
+++ b/specs/specs.js
@@ -1,0 +1,135 @@
+var specResults = {}
+var tree_view = null;
+
+document.addEventListener('DOMContentLoaded', () => {
+  tree_view = new TreeView(document.querySelector('.tree-view-root'))
+
+  fetch('/specs/current.json')
+    .then(res => res.json())
+    .then(data => {
+      specResults = data.stats
+
+      renderDate(data.date)
+
+      // If a search query was passed we execute the search instead of displaying
+      // all spec results.
+      if(window.location.search.length !== 0) {
+        var params = new URLSearchParams(window.location.search)
+        if(params.has('q')) {
+          var query = params.get('q')
+          if(query.length > 0) {
+            document.querySelector('#search').value = query
+            search(query);
+            return;
+          }
+        }
+      }
+
+      tree_view.rerender(specResults, true)
+    })
+    .catch(error => {
+      console.log(error)
+    })
+
+  // If clicked on a tree node
+  document.querySelector('.tree-view-root').addEventListener('click', (e) => {
+    if(e.target.tagName === 'A') return;
+
+    var header = e.target.closest('.tree-view-header')
+    if(header && header.hasAttribute('for')) {
+      var target = header.getAttribute('for')
+      var element = header.parentElement.querySelector(`#${target}`)
+      if(element) {
+        var path = element.dataset.path.split('/')
+        var node = tree_view.getNodeByPath(path)
+        if(element.classList.contains('active')) {
+          node.close()
+        } else {
+          node.open()
+        }
+      }
+    }
+  })
+
+  // On writing to the search input. This will be delayed by 1s to prevent
+  // continous re-searching.
+  var searchTimeout = null
+  document.getElementById('search').addEventListener('input', (e) => {
+    if(searchTimeout) {
+      clearTimeout(searchTimeout)
+    }
+
+    var target = e.currentTarget;
+    searchTimeout = setTimeout(() => {
+      search(target.value)
+    }, 1000)
+  })
+});
+
+// Perform a search on the query. If the query is empty all spec results will be rerendered.
+function search(query) {
+  query = query.trim().toLowerCase()
+  var basePath = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+  if(query.length == 0) {
+    window.history.pushState(null, null, basePath)
+    tree_view.rerender(specResults, true)
+    return
+  }
+
+  var urlParams = new URLSearchParams()
+  urlParams.set('q', query);
+  window.history.pushState(null, null, `${basePath}?${urlParams.toString()}`)
+  var copy = JSON.parse(JSON.stringify(specResults))
+
+  searchObject(query, copy)
+  tree_view.rerender(copy)
+  tree_view.openRecursively()
+}
+
+// Searches through a javascript object using the #matches method to to check whether
+// a key is found by query. This search operation is running recursively => depth-first search
+function searchObject(query, object, path = []) {
+  var regex = new RegExp(query);
+  Object.entries(object).forEach(([key, value]) => {
+    var newPath = path.concat(key)
+    if(value.compiled === undefined) {
+      // In this case value is a spec directory. We run the search recursively in this
+      // directory until a directory or spec file name matches the query.
+      // If the search in the directory returned an empty object and the directory itself
+      // does not match we remove it from object.
+      if(!matches(regex, key, newPath)) {
+        searchObject(query, value, newPath)
+        if(Object.keys(value).length == 0) {
+          delete object[key]
+        }
+      }
+    } else
+    if(!matches(regex, key, newPath)) {
+      // Remove the spec file if it's name does not match the query
+      delete object[key]
+    }
+  })
+}
+
+// Matching function for a query against a directory/file name and it's path.
+// Example: We are matching for key = "push_spec.rb", path = ["core", "array", "push_spec.rb"]
+//    query: core => matches
+//    query: push_spec => matches
+//    query: Array#push => matches
+//    query: array/core/push => matches
+//    query: coarr => does not match
+//    query: co/arr => does not match
+function matches(regex, key, path) {
+  return key.match(regex) ||
+    path.join('').match(regex) ||
+    path.join(' ').match(regex) ||
+    path.join('/').match(regex) ||
+    path.join('#').match(regex)
+}
+
+// Render the time the specs ran last into the introduction paragraph.
+function renderDate(date) {
+  var dateContainer = document.querySelector('#spec-date')
+  dateContainer.textContent = new Date(date).toUTCString()
+  dateContainer.parentElement.style = null
+}

--- a/specs/tree-view.css
+++ b/specs/tree-view.css
@@ -1,0 +1,149 @@
+:root {
+  --success-color: #64dd17;
+  --failure-color: #ab47bc;
+  --error-color: #b71c1c;
+  --compile-error-color: #000000;
+  --timeout-color: #888888;
+  --crash-color: #830a46;
+}
+
+.tree-view-body:not(.active) {
+  display: none;
+}
+
+.tree-view-header {
+  margin: 1em 0 1em 0;
+  display: flex;
+  cursor: pointer;
+}
+
+.tree-view-title {
+  flex-grow: 1;
+}
+
+/* Opened and closed icons for each tree view entry */
+.tree-view-header[for] .tree-view-title:before {
+  content: '▸ ';
+}
+
+.tree-view-header.active[for] .tree-view-title:before {
+  content: '▾ ';
+}
+
+/* Stats */
+.tree-view-stats {
+  display: flex;
+}
+
+.tree-view-stats .stats-counter {
+  margin-right: 1em;
+  display: flex
+}
+
+.tree-view-stats .stats-counter div {
+  font-weight: bold;
+  width: 4ch;
+  text-align: right;
+}
+
+
+/* All stats counter variants */
+.stats-counter.success div {
+  color: var(--success-color);
+}
+.stats-counter.success:after {
+  content: 'passed';
+  margin-left: 3px;
+}
+
+.stats-counter.failures div {
+  color: var(--failure-color);
+}
+.stats-counter.failures:after {
+  content: 'failed';
+  margin-left: 3px;
+}
+
+.stats-counter.errors div {
+  color: var(--error-color);
+}
+.stats-counter.errors:after {
+  content: 'errored';
+  margin-left: 3px;
+}
+
+.stats-counter.compiled {
+  color: var(--compile-error-color);
+}
+.stats-counter.compiled:after {
+  content: 'compilation errors';
+  margin-left: 3px;
+}
+
+.stats-counter.timeouted div {
+  color: var(--timeout-color);
+}
+.stats-counter.timeouted:after {
+  content: 'timed out';
+  margin-left: 3px;
+}
+
+.stats-counter.crashed div {
+  color: var(--crash-color);
+}
+.stats-counter.crashed:after {
+  content: 'crashed';
+  margin-left: 3px;
+}
+
+
+/* Progress bar */
+.progress-bar {
+  width: 200px;
+  height: 20px;
+  display: flex;
+}
+
+.progress-bar-success {
+  background-color: var(--success-color);
+}
+
+.progress-bar-failures {
+  background-color: var(--failure-color);
+}
+
+.progress-bar-errors {
+  background-color: var(--error-color);
+}
+
+
+/* Error message container (containing backtrace and error message) */
+.error-message {
+  background: #ffffff;
+  overflow: auto;
+  width: auto;
+  border: solid gray;
+  border-width: .1em .1em .1em .8em;
+  padding: .2em .6em;
+}
+
+
+/* Media queries for minimal responsiveness */
+@media only screen and (max-width: 1480px) {
+  .tree-view-header, .tree-view-stats {
+    flex-direction: column;
+  }
+
+  .tree-view-stats {
+    display: none;
+    margin-right: 0 !important;
+  }
+
+  .progress-bar {
+    margin-left: 5ch;
+  }
+
+  .tree-view-header.active .tree-view-stats {
+    display: flex;
+  }
+}

--- a/specs/tree_view.js
+++ b/specs/tree_view.js
@@ -1,0 +1,56 @@
+class TreeView {
+  constructor(container) {
+    this.container = container
+  }
+
+  // Creates a root node if the data has a spec key.
+  setData(data) {
+    this.data = data
+    if(data.spec) {
+      this.rootNode = new DirectoryNode('spec', this, data.spec)
+    } else {
+      this.rootNode = null
+    }
+  }
+
+  // Clear the container and render in the spec results.
+  render(opened = false) {
+    while (this.container.firstChild) {
+      this.container.removeChild(this.container.lastChild);
+    }
+
+    if(this.rootNode) {
+      this.rootNode.render(opened)
+    } else {
+      var noResults = document.createElement('p')
+      noResults.textContent = 'No results found.'
+      this.container.append(noResults)
+      return
+    }
+  }
+
+  rerender(data, opened = false) {
+    this.setData(data)
+    this.render(opened)
+  }
+
+  // If a root node exists we open it recursively.
+  openRecursively() {
+    if(this.rootNode)
+      this.rootNode.openRecursively()
+  }
+
+  // Get a node by its path. This performs a recursive search in all child nodes.
+  // One can retrieve the path from the data attributes of each tree view body.
+  getNodeByPath(path) {
+    var currentNode = this.rootNode
+    path.slice(1).forEach(part => {
+      if(currentNode instanceof FileNode) {
+        currentNode = currentNode.findChildNode(part) || currentNode
+      } else {
+        currentNode = currentNode.findChildNode(part)
+      }
+    })
+    return currentNode
+  }
+}


### PR DESCRIPTION
# Detailed Natalie Spec Results

This PR adds a really detailed view about the current status of Natalie's ruby/spec compatibility. 

## Features

* Tree-view structure of all specs in ruby/spec
* Live data from the last ruby/spec run in Natalie's repo.
* Search for a spec or a folder (for example: Array#slice, array/slice, corearray, ...)
* Links to the specs
* Backtrace and error message of failing specs
* Links to failing specs leading to the ruby/spec repository
* Progress bar of successful, failing and erroring specs

## Dependencies

Before merging / deploying this seven1m/natalie#256 and seven1m/natalie-spec-stats-api#1 should be merged and deployed. Also we may want to wait after the first spec run in the natalie repo finished (otherwise the site will be pretty blank).

## Footage

<img src="https://s9.gifyu.com/images/natalie_specs.gif" width="100%" />

([full quality](https://s10.gifyu.com/images/natalie_spec_viewer.gif))

Please give me some feedback on this. We can definitely talk about the choice of colors or text changes (or anything else really).

I checked and all of the stuff *should* be compatible with latest Chromium, Firefox and Safari browsers. However, I cannot verify it on Safari as I do not own an Apple device. 

The page works on mobile, it just does not look *that* nice.
