### PR TITLE
Change external link icon

### DIFF
--- a/specs/node.js
+++ b/specs/node.js
@@ -54,7 +54,7 @@ class Node {
     linkContainer.href = `https://www.github.com/ruby/spec/tree/master/${linkPath}`
     linkContainer.target = '_blank'
     linkContainer.rel = 'noopener noreferrer'
-    linkContainer.textContent = '🡕'
+    linkContainer.textContent = '↗'
     title.innerHTML += ' '
     title.append(linkContainer)
   }


### PR DESCRIPTION
This seems to be better supported by different OS' and browsers. At least it works with Firefox for Android.

We're now using ↗ (North East Arrow). I cannot test it on iOS though. Can somebody confirm that this character is displayed correctly on a mobile iOS browser?