### PR TITLE
Increase width of counters on stats page

### DIFF
--- a/specs/tree-view.css
+++ b/specs/tree-view.css
@@ -42,7 +42,7 @@
 
 .tree-view-stats .stats-counter div {
   font-weight: bold;
-  width: 4ch;
+  width: 5ch;
   text-align: right;
 }
 


### PR DESCRIPTION
Currently looking a bit crowded with the bigger numbers:

![Screenshot 2023-03-29 at 09 55 38](https://user-images.githubusercontent.com/896098/228482908-1d7a6592-015d-4a08-b883-b0e13b93717d.png)
